### PR TITLE
fix: add btcAddress to BIP-322 curl examples

### DIFF
--- a/.claude/skills/loop-start/SKILL.md
+++ b/.claude/skills/loop-start/SKILL.md
@@ -350,7 +350,7 @@ Register:
 ```bash
 RESPONSE=$(curl -s -w "\n%{http_code}" -X POST https://aibtc.com/api/register \
   -H "Content-Type: application/json" \
-  -d '{"bitcoinSignature":"<btc_sig>","stacksSignature":"<stx_sig>"}')
+  -d '{"bitcoinSignature":"<btc_sig>","stacksSignature":"<stx_sig>","btcAddress":"<btc_address>"}')
 HTTP_CODE=$(echo "$RESPONSE" | tail -1)
 BODY=$(echo "$RESPONSE" | head -1)
 if [ "$HTTP_CODE" != "200" ] && [ "$HTTP_CODE" != "201" ]; then
@@ -414,7 +414,7 @@ POST:
 ```bash
 HB_RESPONSE=$(curl -s -w "\n%{http_code}" -X POST https://aibtc.com/api/heartbeat \
   -H "Content-Type: application/json" \
-  -d '{"signature":"<base64_sig>","timestamp":"<timestamp>"}')
+  -d '{"signature":"<base64_sig>","timestamp":"<timestamp>","btcAddress":"<btc_address>"}')
 HB_CODE=$(echo "$HB_RESPONSE" | tail -1)
 HB_BODY=$(echo "$HB_RESPONSE" | head -1)
 if [ "$HB_CODE" != "200" ] && [ "$HB_CODE" != "201" ]; then

--- a/.claude/skills/loop-start/daemon/loop.md
+++ b/.claude/skills/loop-start/daemon/loop.md
@@ -22,7 +22,7 @@ Unlock wallet if STATE.md says locked. Load MCP tools if not present.
 ## Phase 1: Heartbeat
 
 Sign `"AIBTC Check-In | {timestamp}"` (fresh UTC .000Z).
-POST to `https://aibtc.com/api/heartbeat` with `{signature, timestamp}`.
+POST to `https://aibtc.com/api/heartbeat` with `{signature, timestamp, btcAddress}`.
 Use curl, NOT execute_x402_endpoint.
 
 **Reads: nothing.** Addresses are in context from CLAUDE.md.

--- a/SKILL.md
+++ b/SKILL.md
@@ -350,7 +350,7 @@ Register:
 ```bash
 RESPONSE=$(curl -s -w "\n%{http_code}" -X POST https://aibtc.com/api/register \
   -H "Content-Type: application/json" \
-  -d '{"bitcoinSignature":"<btc_sig>","stacksSignature":"<stx_sig>"}')
+  -d '{"bitcoinSignature":"<btc_sig>","stacksSignature":"<stx_sig>","btcAddress":"<btc_address>"}')
 HTTP_CODE=$(echo "$RESPONSE" | tail -1)
 BODY=$(echo "$RESPONSE" | head -1)
 if [ "$HTTP_CODE" != "200" ] && [ "$HTTP_CODE" != "201" ]; then
@@ -414,7 +414,7 @@ POST:
 ```bash
 HB_RESPONSE=$(curl -s -w "\n%{http_code}" -X POST https://aibtc.com/api/heartbeat \
   -H "Content-Type: application/json" \
-  -d '{"signature":"<base64_sig>","timestamp":"<timestamp>"}')
+  -d '{"signature":"<base64_sig>","timestamp":"<timestamp>","btcAddress":"<btc_address>"}')
 HB_CODE=$(echo "$HB_RESPONSE" | tail -1)
 HB_BODY=$(echo "$HB_RESPONSE" | head -1)
 if [ "$HB_CODE" != "200" ] && [ "$HB_CODE" != "201" ]; then

--- a/daemon/loop.md
+++ b/daemon/loop.md
@@ -22,7 +22,7 @@ Unlock wallet if STATE.md says locked. Load MCP tools if not present.
 ## Phase 1: Heartbeat
 
 Sign `"AIBTC Check-In | {timestamp}"` (fresh UTC .000Z).
-POST to `https://aibtc.com/api/heartbeat` with `{signature, timestamp}`.
+POST to `https://aibtc.com/api/heartbeat` with `{signature, timestamp, btcAddress}`.
 Use curl, NOT execute_x402_endpoint.
 
 **Reads: nothing.** Addresses are in context from CLAUDE.md.


### PR DESCRIPTION
## Summary

Fixes #2 — Agents with native SegWit (`bc1q`) addresses use BIP-322 signatures. Both `/api/register` and `/api/heartbeat` require a `btcAddress` field in the POST body for BIP-322 verification, but the setup instructions and loop docs were missing it. This caused registration and heartbeat failures for new agents.

**Changes:**
- Added `"btcAddress":"<btc_address>"` to the `/api/register` curl example JSON body in both copies of `SKILL.md`
- Added `"btcAddress":"<btc_address>"` to the `/api/heartbeat` curl example JSON body in both copies of `SKILL.md`
- Updated the heartbeat POST description in both copies of `daemon/loop.md` to include `btcAddress`

**Files changed:**
- `SKILL.md` (root) — register and heartbeat curl examples
- `.claude/skills/loop-start/SKILL.md` — register and heartbeat curl examples
- `daemon/loop.md` — Phase 1 heartbeat POST description
- `.claude/skills/loop-start/daemon/loop.md` — Phase 1 heartbeat POST description

## Test plan

- [ ] Verify new agent setup with BIP-322 wallet completes registration without manual btcAddress workaround
- [ ] Verify heartbeat POST succeeds for agents with `bc1q` addresses using the updated curl example
- [ ] Confirm no other references to the heartbeat/register JSON bodies were missed

🤖 Generated with [Claude Code](https://claude.com/claude-code)