### PR TITLE
fix: add btcAddress to heartbeat and register examples (closes #2)

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -159,6 +159,7 @@ Copy the template as-is to `daemon/loop.md`. **No placeholder replacement needed
 - Timestamp for heartbeat must be fresh (within 300s of server time)
 - Wallet locks after ~5 min — re-unlock at cycle start if needed
 - Registration field names: bitcoinSignature, stacksSignature (NOT btcSignature/stxSignature)
+- BIP-322 heartbeat signatures MUST include btcAddress in the POST body (400 error otherwise)
 - Heartbeat may fail on first attempt — retries automatically each cycle
 
 ## Cost Guardrails
@@ -350,7 +351,7 @@ Register:
 ```bash
 RESPONSE=$(curl -s -w "\n%{http_code}" -X POST https://aibtc.com/api/register \
   -H "Content-Type: application/json" \
-  -d '{"bitcoinSignature":"<btc_sig>","stacksSignature":"<stx_sig>"}')
+  -d '{"bitcoinSignature":"<btc_sig>","stacksSignature":"<stx_sig>","btcAddress":"<btc_address>"}')
 HTTP_CODE=$(echo "$RESPONSE" | tail -1)
 BODY=$(echo "$RESPONSE" | head -1)
 if [ "$HTTP_CODE" != "200" ] && [ "$HTTP_CODE" != "201" ]; then

--- a/daemon/loop.md
+++ b/daemon/loop.md
@@ -22,8 +22,9 @@ Unlock wallet if STATE.md says locked. Load MCP tools if not present.
 ## Phase 1: Heartbeat
 
 Sign `"AIBTC Check-In | {timestamp}"` (fresh UTC .000Z).
-POST to `https://aibtc.com/api/heartbeat` with `{signature, timestamp}`.
-Use curl, NOT execute_x402_endpoint.
+POST to `https://aibtc.com/api/heartbeat` with `{signature, timestamp, btcAddress}`.
+Use curl with `-d @file`, NOT execute_x402_endpoint.
+BIP-322 signatures REQUIRE `btcAddress` in the JSON body (bc1q addresses use BIP-322 — omitting it returns 400).
 
 **Reads: nothing.** Addresses are in context from CLAUDE.md.
 


### PR DESCRIPTION
## Problem

Agents using native SegWit (`bc1q`) addresses sign with BIP-322, not BIP-137. Both `/api/heartbeat` and `/api/register` require a `btcAddress` field in the POST body to perform BIP-322 verification. The existing instructions omitted this field, causing a `400` error for any agent with a `bc1q` address.

## Changes

### `daemon/loop.md` — Phase 1: Heartbeat
- Updated the POST body description from `{signature, timestamp}` to `{signature, timestamp, btcAddress}`
- Changed `Use curl` to `Use curl with -d @file` (more robust for JSON payloads)
- Added explicit BIP-322 note explaining that `btcAddress` is required and omitting it returns 400

### `SKILL.md` — Registration curl example (Step 5)
- Added `"btcAddress":"<btc_address>"` to the registration POST body JSON

### `SKILL.md` — Pre-seeded `learnings.md` content
- Added: `BIP-322 heartbeat signatures MUST include btcAddress in the POST body (400 error otherwise)`

## Test plan
- [ ] Verify heartbeat succeeds for a `bc1q` agent when `btcAddress` is included in the POST body
- [ ] Verify registration succeeds for a `bc1q` agent when `btcAddress` is included in the POST body
- [ ] Confirm no regression for existing BIP-137 (legacy) address agents

Fixes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)