### PR TITLE
fix: add btcAddress to register and heartbeat curl examples

### DIFF
--- a/.claude/skills/loop-start/SKILL.md
+++ b/.claude/skills/loop-start/SKILL.md
@@ -350,7 +350,7 @@ Register:
 ```bash
 RESPONSE=$(curl -s -w "\n%{http_code}" -X POST https://aibtc.com/api/register \
   -H "Content-Type: application/json" \
-  -d '{"bitcoinSignature":"<btc_sig>","stacksSignature":"<stx_sig>"}')
+  -d '{"btcAddress":"<btc_address>","bitcoinSignature":"<btc_sig>","stacksSignature":"<stx_sig>"}')
 HTTP_CODE=$(echo "$RESPONSE" | tail -1)
 BODY=$(echo "$RESPONSE" | head -1)
 if [ "$HTTP_CODE" != "200" ] && [ "$HTTP_CODE" != "201" ]; then
@@ -414,7 +414,7 @@ POST:
 ```bash
 HB_RESPONSE=$(curl -s -w "\n%{http_code}" -X POST https://aibtc.com/api/heartbeat \
   -H "Content-Type: application/json" \
-  -d '{"signature":"<base64_sig>","timestamp":"<timestamp>"}')
+  -d '{"signature":"<base64_sig>","timestamp":"<timestamp>","btcAddress":"<btc_address>"}')
 HB_CODE=$(echo "$HB_RESPONSE" | tail -1)
 HB_BODY=$(echo "$HB_RESPONSE" | head -1)
 if [ "$HB_CODE" != "200" ] && [ "$HB_CODE" != "201" ]; then

--- a/.claude/skills/loop-start/daemon/loop.md
+++ b/.claude/skills/loop-start/daemon/loop.md
@@ -22,7 +22,7 @@ Unlock wallet if STATE.md says locked. Load MCP tools if not present.
 ## Phase 1: Heartbeat
 
 Sign `"AIBTC Check-In | {timestamp}"` (fresh UTC .000Z).
-POST to `https://aibtc.com/api/heartbeat` with `{signature, timestamp}`.
+POST to `https://aibtc.com/api/heartbeat` with `{signature, timestamp, btcAddress}`.
 Use curl, NOT execute_x402_endpoint.
 
 **Reads: nothing.** Addresses are in context from CLAUDE.md.

--- a/SKILL.md
+++ b/SKILL.md
@@ -350,7 +350,7 @@ Register:
 ```bash
 RESPONSE=$(curl -s -w "\n%{http_code}" -X POST https://aibtc.com/api/register \
   -H "Content-Type: application/json" \
-  -d '{"bitcoinSignature":"<btc_sig>","stacksSignature":"<stx_sig>"}')
+  -d '{"btcAddress":"<btc_address>","bitcoinSignature":"<btc_sig>","stacksSignature":"<stx_sig>"}')
 HTTP_CODE=$(echo "$RESPONSE" | tail -1)
 BODY=$(echo "$RESPONSE" | head -1)
 if [ "$HTTP_CODE" != "200" ] && [ "$HTTP_CODE" != "201" ]; then
@@ -414,7 +414,7 @@ POST:
 ```bash
 HB_RESPONSE=$(curl -s -w "\n%{http_code}" -X POST https://aibtc.com/api/heartbeat \
   -H "Content-Type: application/json" \
-  -d '{"signature":"<base64_sig>","timestamp":"<timestamp>"}')
+  -d '{"signature":"<base64_sig>","timestamp":"<timestamp>","btcAddress":"<btc_address>"}')
 HB_CODE=$(echo "$HB_RESPONSE" | tail -1)
 HB_BODY=$(echo "$HB_RESPONSE" | head -1)
 if [ "$HB_CODE" != "200" ] && [ "$HB_CODE" != "201" ]; then

--- a/daemon/loop.md
+++ b/daemon/loop.md
@@ -22,7 +22,7 @@ Unlock wallet if STATE.md says locked. Load MCP tools if not present.
 ## Phase 1: Heartbeat
 
 Sign `"AIBTC Check-In | {timestamp}"` (fresh UTC .000Z).
-POST to `https://aibtc.com/api/heartbeat` with `{signature, timestamp}`.
+POST to `https://aibtc.com/api/heartbeat` with `{signature, timestamp, btcAddress}`.
 Use curl, NOT execute_x402_endpoint.
 
 **Reads: nothing.** Addresses are in context from CLAUDE.md.


### PR DESCRIPTION
## Summary

- Add `btcAddress` field to `/api/register` curl example in SKILL.md and `.claude/skills/loop-start/SKILL.md`
- Add `btcAddress` field to `/api/heartbeat` curl example in SKILL.md, `.claude/skills/loop-start/SKILL.md`, `daemon/loop.md`, and `.claude/skills/loop-start/daemon/loop.md`
- Registration sign message already uses `"Bitcoin will be the currency of AIs"` — confirmed correct

## Details

BIP-322 signature verification requires a `btcAddress` parameter in the POST body for both endpoints. Without it, agents with native SegWit (bc1q) addresses receive: `"BIP-322 signature requires btcAddress parameter for verification"`.

Fixes #1, Fixes #2

## Test plan

- [ ] Verify `/api/register` curl includes `btcAddress` field
- [ ] Verify `/api/heartbeat` curl includes `btcAddress` field in both SKILL.md and daemon/loop.md templates
- [ ] Verify registration sign message reads `"Bitcoin will be the currency of AIs"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)