### PR TITLE
fix(loop-starter-kit): add btcAddress to BIP-322 curl examples

### DIFF
--- a/.claude/skills/loop-start/SKILL.md
+++ b/.claude/skills/loop-start/SKILL.md
@@ -350,7 +350,7 @@ Register:
 ```bash
 RESPONSE=$(curl -s -w "\n%{http_code}" -X POST https://aibtc.com/api/register \
   -H "Content-Type: application/json" \
-  -d '{"bitcoinSignature":"<btc_sig>","stacksSignature":"<stx_sig>"}')
+  -d '{"btcAddress":"<btc_address>","bitcoinSignature":"<btc_sig>","stacksSignature":"<stx_sig>"}')
 HTTP_CODE=$(echo "$RESPONSE" | tail -1)
 BODY=$(echo "$RESPONSE" | head -1)
 if [ "$HTTP_CODE" != "200" ] && [ "$HTTP_CODE" != "201" ]; then
@@ -414,7 +414,7 @@ POST:
 ```bash
 HB_RESPONSE=$(curl -s -w "\n%{http_code}" -X POST https://aibtc.com/api/heartbeat \
   -H "Content-Type: application/json" \
-  -d '{"signature":"<base64_sig>","timestamp":"<timestamp>"}')
+  -d '{"btcAddress":"<btc_address>","signature":"<base64_sig>","timestamp":"<timestamp>"}')
 HB_CODE=$(echo "$HB_RESPONSE" | tail -1)
 HB_BODY=$(echo "$HB_RESPONSE" | head -1)
 if [ "$HB_CODE" != "200" ] && [ "$HB_CODE" != "201" ]; then

--- a/SKILL.md
+++ b/SKILL.md
@@ -350,7 +350,7 @@ Register:
 ```bash
 RESPONSE=$(curl -s -w "\n%{http_code}" -X POST https://aibtc.com/api/register \
   -H "Content-Type: application/json" \
-  -d '{"bitcoinSignature":"<btc_sig>","stacksSignature":"<stx_sig>"}')
+  -d '{"btcAddress":"<btc_address>","bitcoinSignature":"<btc_sig>","stacksSignature":"<stx_sig>"}')
 HTTP_CODE=$(echo "$RESPONSE" | tail -1)
 BODY=$(echo "$RESPONSE" | head -1)
 if [ "$HTTP_CODE" != "200" ] && [ "$HTTP_CODE" != "201" ]; then
@@ -414,7 +414,7 @@ POST:
 ```bash
 HB_RESPONSE=$(curl -s -w "\n%{http_code}" -X POST https://aibtc.com/api/heartbeat \
   -H "Content-Type: application/json" \
-  -d '{"signature":"<base64_sig>","timestamp":"<timestamp>"}')
+  -d '{"btcAddress":"<btc_address>","signature":"<base64_sig>","timestamp":"<timestamp>"}')
 HB_CODE=$(echo "$HB_RESPONSE" | tail -1)
 HB_BODY=$(echo "$HB_RESPONSE" | head -1)
 if [ "$HB_CODE" != "200" ] && [ "$HB_CODE" != "201" ]; then

--- a/daemon/loop.md
+++ b/daemon/loop.md
@@ -22,7 +22,7 @@ Unlock wallet if STATE.md says locked. Load MCP tools if not present.
 ## Phase 1: Heartbeat
 
 Sign `"AIBTC Check-In | {timestamp}"` (fresh UTC .000Z).
-POST to `https://aibtc.com/api/heartbeat` with `{signature, timestamp}`.
+POST to `https://aibtc.com/api/heartbeat` with `{btcAddress, signature, timestamp}`.
 Use curl, NOT execute_x402_endpoint.
 
 **Reads: nothing.** Addresses are in context from CLAUDE.md.


### PR DESCRIPTION
## Summary

Fixes #7

- BIP-322 signature verification requires `btcAddress` in the POST body
- Without this field, agents with native SegWit (`bc1q`) addresses receive: `"BIP-322 signature requires btcAddress parameter for verification"`
- Added `btcAddress` to the `/api/register` and `/api/heartbeat` curl examples in all affected files

## Files changed

- `SKILL.md` — register and heartbeat curl examples updated
- `.claude/skills/loop-start/SKILL.md` — same (duplicate copy)
- `daemon/loop.md` — heartbeat phase description updated

## Test plan

- [ ] Verify `/api/register` curl example includes `btcAddress` in JSON body
- [ ] Verify `/api/heartbeat` curl example includes `btcAddress` in JSON body
- [ ] Verify `daemon/loop.md` heartbeat phase description references `btcAddress`
- [ ] Confirm no other curl examples for these endpoints are missing the field

Generated with [Claude Code](https://claude.com/claude-code)