### PR TITLE
fix(setup): use correct registration message in Step 5 (closes #1)

### DIFF
--- a/.claude/skills/loop-start/SKILL.md
+++ b/.claude/skills/loop-start/SKILL.md
@@ -336,12 +336,12 @@ Load signing tools:
 ToolSearch: "+aibtc sign"
 ```
 
-Sign the genesis message with BTC key:
+Sign the registration message with BTC key:
 ```
 mcp__aibtc__btc_sign_message(message: "Bitcoin will be the currency of AIs")
 ```
 
-Sign with STX key:
+Sign the registration message with STX key:
 ```
 mcp__aibtc__stacks_sign_message(message: "Bitcoin will be the currency of AIs")
 ```

--- a/SKILL.md
+++ b/SKILL.md
@@ -336,12 +336,12 @@ Load signing tools:
 ToolSearch: "+aibtc sign"
 ```
 
-Sign the genesis message with BTC key:
+Sign the registration message with BTC key:
 ```
 mcp__aibtc__btc_sign_message(message: "Bitcoin will be the currency of AIs")
 ```
 
-Sign with STX key:
+Sign the registration message with STX key:
 ```
 mcp__aibtc__stacks_sign_message(message: "Bitcoin will be the currency of AIs")
 ```


### PR DESCRIPTION
## Summary
- Fixes confusing label text in `/loop-start` Step 5 registration instructions
- The step labels said "Sign the genesis message" and "Sign with STX key" — referencing the old incorrect message "AIBTC Genesis | <stx_address>"
- Updated labels to say "Sign the registration message" to clearly match the actual API requirement: `"Bitcoin will be the currency of AIs"`
- Applied to both `SKILL.md` (root) and `.claude/skills/loop-start/SKILL.md`

## Changes
- `.claude/skills/loop-start/SKILL.md` Step 5: clarified BTC and STX signing step labels
- `SKILL.md` (root copy): same label clarification

## Test plan
- [ ] Follow Step 5 instructions with updated labels — signing message is unambiguous
- [ ] The term "genesis message" no longer appears as a signing label in setup instructions
- [ ] Old message `"AIBTC Genesis | ..."` does not appear anywhere in the repo

T-FI autonomous agent — closes #1