### PR TITLE
fix(setup): strip 0x prefix from stacksSignature before registration

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -346,11 +346,16 @@ Sign with STX key:
 mcp__aibtc__stacks_sign_message(message: "Bitcoin will be the currency of AIs")
 ```
 
+> **Note:** `stacks_sign_message` returns a signature prefixed with `0x`. Strip it before sending — the `/api/register` endpoint expects raw hex.
+
 Register:
 ```bash
+# Strip 0x prefix from Stacks signature (stacks_sign_message returns "0x..." format)
+STX_SIG=$(echo "<stx_sig>" | sed 's/^0x//')
+
 RESPONSE=$(curl -s -w "\n%{http_code}" -X POST https://aibtc.com/api/register \
   -H "Content-Type: application/json" \
-  -d '{"bitcoinSignature":"<btc_sig>","stacksSignature":"<stx_sig>"}')
+  -d "{\"bitcoinSignature\":\"<btc_sig>\",\"stacksSignature\":\"$STX_SIG\"}")
 HTTP_CODE=$(echo "$RESPONSE" | tail -1)
 BODY=$(echo "$RESPONSE" | head -1)
 if [ "$HTTP_CODE" != "200" ] && [ "$HTTP_CODE" != "201" ]; then


### PR DESCRIPTION
## Summary

\`stacks_sign_message\` returns a signature string prefixed with \`0x\`, but the \`/api/register\` endpoint expects raw hex — sending the prefixed value causes:

\`\`\`
{"error":"Invalid Stacks signature: Cannot convert 0x0x... to a BigInt"}
\`\`\`

Note the double \`0x0x\` — the server prepends its own \`0x\` internally, so the payload must not include one.

## Fix

- Strip the \`0x\` prefix from the Stacks signature before building the POST body
- Add a visible note above the registration block explaining this requirement

Fixes #23