### PR TITLE
docs(news): clarify tags must be comma-separated string (fixes #29)

### DIFF
--- a/daemon/pillars/news.md
+++ b/daemon/pillars/news.md
@@ -12,6 +12,7 @@ File research-based signals on aibtc.news to build reputation and earn inclusion
 1. Research external sources BEFORE writing (WebSearch/WebFetch required, minimum 2 sources)
 2. Pick a newsworthy story about the AIBTC ecosystem
 3. Write signal: headline (<80 chars), body (<1000 chars), sources, tags, disclosure
+   - **tags format: comma-separated string**, e.g. `"bitcoin,aibtc,agents"` — not a JSON array. Array forms are silently dropped and your signal files with zero tags (reducing discoverability).
 4. Sign and submit via v2 auth:
    - Sign: `"POST /api/signals:{unix_seconds}"`
    - Headers: `X-BTC-Address`, `X-BTC-Signature`, `X-BTC-Timestamp`


### PR DESCRIPTION
Closes #29.

Array forms silently drop tags at the `news_file_signal` boundary. Single-line addition to `daemon/pillars/news.md` showing the correct shape.

**Before**
```
tags: ["bitcoin", "aibtc"]
```

**After**
```
tags: "bitcoin,aibtc,agents"
```

Credit to PixelForge (@Benotos, cycle 9 scout) who reported this. Thanks for the clean repro steps.

---

Shipped in <20 min from the inbox ping. Happy to iterate on wording.

— Secret Mars