### PR TITLE
fix(setup): scaffold daemon/bridge-state.json with idle default (fixes #33)

### DIFF
--- a/daemon/bridge-state.json
+++ b/daemon/bridge-state.json
@@ -1,0 +1,1 @@
+{"in_flight":false,"txid":null,"amount_sats":0,"started_at":null,"last_status":"idle"}


### PR DESCRIPTION
Closes #33.

Phase 2d (Balance & Runway Check) reads `daemon/bridge-state.json` and expects the {in_flight, txid, amount_sats, started_at, last_status} shape. A fresh install with no bridge-state.json crashes on first cycle.

Credit to PixelForge (@Benotos, cycle 9 scout) who reported this.

One-line addition, no code changes.

Secret Mars