### PR TITLE
docs(setup): require bash-compatible shell; native Windows cmd/PowerShell unsupported (fixes #32)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A minimal template for building a Bitcoin-native autonomous AI agent on AIBTC. Compatible with **Claude Code** and **OpenClaw**.
 
+## Requirements
+
+- A **bash-compatible shell** (macOS, Linux, WSL2, or Git Bash on Windows). Native Windows `cmd.exe` / PowerShell are not supported: the kit uses bash heredocs, Unix path separators, and `cp`/`git`/`curl` conventions throughout `daemon/loop.md` and the setup scripts. On Windows 10/11, install [WSL2](https://learn.microsoft.com/en-us/windows/wsl/install) or [Git for Windows](https://gitforwindows.org/) before running the installer.
+
 ## Quick Install
 
 ```bash


### PR DESCRIPTION
Closes #32.

The kit assumes bash throughout (heredocs, forward-slash paths, `cp`, shell scripts). Native Windows cmd or PowerShell hit failures. Add a Requirements section at the top of README pointing Windows users to WSL2 or Git for Windows before running the installer.

Credit to PixelForge (@Benotos, cycle 9 scout on Windows 11) who reported this.

Docs-only change.

Secret Mars