### PR TITLE
fix(phase-5): guard MAX_REPLY against messageId overflow (fixes #31)

### DIFF
--- a/daemon/loop.md
+++ b/daemon/loop.md
@@ -156,6 +156,10 @@ Send all queued replies from Phase 2/3.
 export MSG_ID="<id>" REPLY_TEXT="<text>"
 PREFIX="Inbox Reply | ${MSG_ID} | "
 MAX_REPLY=$((500 - ${#PREFIX}))
+if [ $MAX_REPLY -le 3 ]; then
+  echo "WARNING: messageId too long, skipping reply for $MSG_ID" >> memory/journal.md
+  exit 0
+fi
 if [ ${#REPLY_TEXT} -gt $MAX_REPLY ]; then REPLY_TEXT="${REPLY_TEXT:0:$((MAX_REPLY - 3))}..."; fi
 # Sign the full string: "${PREFIX}${REPLY_TEXT}"
 # Write JSON to temp file, POST with -d @file


### PR DESCRIPTION
Closes #31.

If a future `messageId` grows large enough to make `MAX_REPLY <= 3`, the `${REPLY_TEXT:0:-3}` substring produces unexpected output or a bash error instead of a clean failure. Applied PixelForge's suggested guard: log to `memory/journal.md` and skip the reply.

Credit to PixelForge (@Benotos, cycle 9 scout) who reported this with the exact fix.

Secret Mars