### PR TITLE
fix(loop): tags as comma-string + MAX_REPLY negative guard

### DIFF
--- a/daemon/loop.md
+++ b/daemon/loop.md
@@ -124,6 +124,7 @@ If you've claimed a beat on aibtc.news, file research-based signals to build rep
 3. Tie external news to what AIBTC agents are doing
 4. Include source URLs. If no genuinely newsworthy story found, skip — quality over quantity.
 5. Rate limit: 1 signal per 4 hours. File daily to maintain streak.
+6. **Tags format:** `tags` must be a comma-separated string: `"bitcoin,aibtc,agents"` — NOT an array. Signals filed with array tags have no tags on aibtc.news.
 
 ---
 
@@ -156,7 +157,11 @@ Send all queued replies from Phase 2/3.
 export MSG_ID="<id>" REPLY_TEXT="<text>"
 PREFIX="Inbox Reply | ${MSG_ID} | "
 MAX_REPLY=$((500 - ${#PREFIX}))
-if [ ${#REPLY_TEXT} -gt $MAX_REPLY ]; then REPLY_TEXT="${REPLY_TEXT:0:$((MAX_REPLY - 3))}..."; fi
+if [ $MAX_REPLY -le 3 ]; then
+  echo "WARNING: messageId too long, skipping reply for $MSG_ID" >&2
+else
+  if [ ${#REPLY_TEXT} -gt $MAX_REPLY ]; then REPLY_TEXT="${REPLY_TEXT:0:$((MAX_REPLY - 3))}..."; fi
+fi
 # Sign the full string: "${PREFIX}${REPLY_TEXT}"
 # Write JSON to temp file, POST with -d @file
 ```
@@ -496,6 +501,7 @@ wSTX rewards accrue continuously. Claim when profitable, not on a fixed schedule
 - Use `-d @file` NOT `-d '...'` — shell mangles base64
 - ASCII only — em-dashes break sig verification
 - One reply per message — outbox API rejects duplicates
+- **Guard against negative MAX_REPLY:** if `MAX_REPLY <= 3` (messageId is extremely long), skip the reply and log a warning — do not attempt truncation, as `${REPLY_TEXT:0:$((MAX_REPLY - 3))}` produces a bash error or empty string when MAX_REPLY is 0, 1, 2, or 3.
 
 ---
 

--- a/daemon/pillars/news.md
+++ b/daemon/pillars/news.md
@@ -12,6 +12,7 @@ File research-based signals on aibtc.news to build reputation and earn inclusion
 1. Research external sources BEFORE writing (WebSearch/WebFetch required, minimum 2 sources)
 2. Pick a newsworthy story about the AIBTC ecosystem
 3. Write signal: headline (<80 chars), body (<1000 chars), sources, tags, disclosure
+   - **tags** must be a comma-separated string: `"bitcoin,aibtc,agents"` — NOT an array. Signals filed with array tags have no tags on aibtc.news.
 4. Sign and submit via v2 auth:
    - Sign: `"POST /api/signals:{unix_seconds}"`
    - Headers: `X-BTC-Address`, `X-BTC-Signature`, `X-BTC-Timestamp`


### PR DESCRIPTION
## Summary

Fixes two bugs in `daemon/loop.md` (and `daemon/pillars/news.md`):

- **Fixes #29** — Tags passed as array instead of comma-separated string: agents reading the Phase 3 News Signals section had no explicit guidance on the `tags` field format, leading to arrays being submitted. Signals filed with array tags have no tags on aibtc.news. Added a clear note: `tags must be a comma-separated string: "bitcoin,aibtc,agents" — NOT an array`. Same note added inline in `daemon/pillars/news.md` step 3.

- **Fixes #31** — MAX_REPLY can be negative (or <= 3): the Phase 5 bash truncation block `${REPLY_TEXT:0:$((MAX_REPLY - 3))}` produces a bash error or empty/malformed output when `MAX_REPLY` is 0, 1, 2, or 3 (i.e. when the messageId is extremely long). Added a guard that skips the reply with a stderr warning instead of attempting truncation. Updated the `## Reply Mechanics` section to document this guard and explain why it is needed.

## Files changed

- `daemon/loop.md` — Phase 3 News Signals note, Phase 5 reply guard, Reply Mechanics documentation
- `daemon/pillars/news.md` — tags format note in step 3

## Test plan

- [ ] Verify Phase 3 news section shows the tags format note
- [ ] Verify Phase 5 bash block includes the `if [ $MAX_REPLY -le 3 ]` guard
- [ ] Verify Reply Mechanics section documents the guard
- [ ] Verify `daemon/pillars/news.md` step 3 shows the tags format note
- [ ] No unrelated sections were modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)