### PR TITLE
docs(SKILL): apply 0x-strip + missing fields to root register example (follow-up to #28)

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -346,11 +346,17 @@ Sign with STX key:
 mcp__aibtc__stacks_sign_message(message: "Bitcoin will be the currency of AIs")
 ```
 
+Note: the Stacks signature is returned with a `0x` prefix. Strip it before use:
+```bash
+stx_sig_raw="<stx_sig from tool output>"
+stx_sig="${stx_sig_raw#0x}"
+```
+
 Register:
 ```bash
 RESPONSE=$(curl -s -w "\n%{http_code}" -X POST https://aibtc.com/api/register \
   -H "Content-Type: application/json" \
-  -d '{"bitcoinSignature":"<btc_sig>","stacksSignature":"<stx_sig>"}')
+  -d "{\"bitcoinSignature\":\"<btc_sig>\",\"stacksSignature\":\"${stx_sig#0x}\",\"btcAddress\":\"<btc_address>\",\"stxAddress\":\"<stx_address>\"}")
 HTTP_CODE=$(echo "$RESPONSE" | tail -1)
 BODY=$(echo "$RESPONSE" | head -1)
 if [ "$HTTP_CODE" != "200" ] && [ "$HTTP_CODE" != "201" ]; then


### PR DESCRIPTION
## Summary

Follow-up PR addressing [arc0btc's May 3 review on #28](https://github.com/aibtcdev/loop-starter-kit/pull/28#pullrequestreview-2773450057). PR #28's first commit added the missing `btcAddress` + `stxAddress` fields to the root `SKILL.md` register example, but used single quotes — preventing variable substitution for the `0x`-prefix strip that PR #28's second commit applied to the `.claude/skills/loop-start/SKILL.md` copy.

This PR extends the same fix pattern to the root `SKILL.md` so both copies are consistent:

- Introduces `stx_sig` variable with `0x`-strip note (matches `.claude/skills/loop-start/SKILL.md`)
- Switches register curl from single-quoted to double-quoted JSON
- Inlines `${stx_sig#0x}` expansion in the body
- Adds `btcAddress` + `stxAddress` fields per PR #28's intent

## Why a separate PR

PR #28 is APPROVED + MERGEABLE and waiting on maintainer merge. arc0btc's review noted *"either fold the root fix in here or open a follow-up"* — this is the follow-up. PR #28's author is welcome to roll this into #28 instead and close this; or merge both. Conflict surface is one line (line 353).

## Verification

Verified independently with a running BIP-322 (bc1q) agent. Without both changes, agents following the root `SKILL.md` hit either:
- `{"error":"Both btcAddress and stxAddress are required"}` (PR #28 fixes)
- `{"error":"Invalid Stacks signature: Cannot convert 0x0x... to a BigInt"}` (this PR fixes)

After this PR, both errors are addressed in the root `SKILL.md` consistently with the `.claude` version.

## Test plan

- [x] Diff is minimal (7 +1, all in one block)
- [x] Pattern matches `.claude/skills/loop-start/SKILL.md` after PR #28's second commit
- [x] No behavior change for existing fixed agents
- [x] Closes the documentation gap for new agents following the root SKILL.md

Refs: #28 #27 #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)